### PR TITLE
Crashes when UAttributeSet has a property other than GamePlayAttribute

### DIFF
--- a/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
+++ b/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
@@ -1046,13 +1046,15 @@ void SGASAttachEditorImpl::UpdateGameplayCueListItems()
 					continue;
 				}
 
-				for (TFieldIterator<FProperty> It(Set->GetClass()); It; ++It)
+				for (TFieldIterator<FStructProperty> It(Set->GetClass()); It; ++It)
 				{
-					FGameplayAttribute	Attribute(*It);
+					if ((*It)->Struct == FGameplayAttributeData::StaticStruct())
+					{
+						FGameplayAttribute	Attribute(*It);
+						TSharedRef<FGASAttributesNode> NewItem = FGASAttributesNode::Create(ASC, Attribute);
 
-					TSharedRef<FGASAttributesNode> NewItem = FGASAttributesNode::Create(ASC, Attribute);
-
-					AttributesFilteredTreeRoot.Add(NewItem);
+						AttributesFilteredTreeRoot.Add(NewItem);
+					}
 				}
 			}
 			AttributesReflectorTree->RequestTreeRefresh();


### PR DESCRIPTION
Reproduction Procedure

1. Attach something other than GamePlayAttribute to the class derived from UAttributeSet. (e.g. EventDispatcher).
2. Place an Actor with that AttributeSet in the level.
3. Select the Attribute display in the GASAttachEditor window and play it.
4. Update the display in the GASAttachEditor window.
5. Error in check macro for "FGameplayAttribute::GetAttributeSetClass
---
Details of change

Added a process to check the type of GamePlayAttribute when collecting it.
