### PR TITLE
Update to UE 5.2

### DIFF
--- a/GASAttachEditor.uplugin
+++ b/GASAttachEditor.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EngineVersion": "5.1.0",
+	"EngineVersion": "5.2.0",
 	"EnabledByDefault": false,
 	"CanContainContent": false,
 	"Installed": false,

--- a/GASAttachEditor.uplugin
+++ b/GASAttachEditor.uplugin
@@ -24,7 +24,8 @@
 			],
 			"WhitelistPlatforms": [
 				"Win64",
-				"Linux"
+				"Linux",
+				"Mac"
 			]
 		}
 	],


### PR DESCRIPTION
Just a simple bump of the supported Engine version as it works as is.

I have additionally whitelisted the "Mac" target platform as I could test successful builds on a M2 Pro Mac.