### PR TITLE
Support 5.3

### DIFF
--- a/GASAttachEditor.uplugin
+++ b/GASAttachEditor.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 1,
-	"VersionName": "1.0",
+	"Version": 2,
+	"VersionName": "1.9",
 	"FriendlyName": "GASAttachEditor",
 	"Description": "Adds an editor panel to debug the Gameplay Ability System",
 	"Category": "Gameplay",
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EngineVersion": "5.2.0",
+	"EngineVersion": "5.3.0",
 	"EnabledByDefault": false,
 	"CanContainContent": false,
 	"Installed": false,

--- a/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
+++ b/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
@@ -568,7 +568,7 @@ void SGASAttachEditorImpl::Construct(const FArguments& InArgs)
 						SNew(STextBlock)
 						//.ToolTipText(LOCTEXT("ShowWorldTypeType", "选择需要查看场景"))
 						.ToolTipText(LOCTEXT("ShowWorldTypeType", "Select World Scene"))
-						.Text_Lambda([=]{return SelectWorldSceneText;})
+						.Text_Lambda([this]{return SelectWorldSceneText;})
 					]
 				]
 


### PR DESCRIPTION
- Replaced `[=]` implicit conversions to `[this]` in lambdas as they're now deprecated in C++20
- Bumped versions
  - _Internal use_ `Version`
  - _Displayed_ `VersionName`
  - `EngineVersion`
