### PR TITLE
Safely get the GAS actor to prevent a crash if the avatar actor is nullptr

### DIFF
--- a/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
+++ b/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
@@ -145,7 +145,7 @@ UAbilitySystemComponent* GetDebugTarget(FASCDebugTargetInfo* Info, const UAbilit
 
 		if (InSelectComponent == ASC.Get() && !bIsSelect)
 		{
-			SelectActorName = ASC->GetAvatarActor_Direct()->GetFName();
+			SelectActorName = GetGASActor(ASC)->GetFName();
 			Info->LastDebugTarget = ASC;
 			bIsSelect = true;
 			break;
@@ -168,7 +168,7 @@ UAbilitySystemComponent* GetDebugTarget(FASCDebugTargetInfo* Info, const UAbilit
 			if (PlayerComp.IsValidIndex(0))
 			{
 				Info->LastDebugTarget = PlayerComp[0];
-				SelectActorName = Info->LastDebugTarget->GetAvatarActor_Direct()->GetFName();
+				SelectActorName = GetGASActor(Info->LastDebugTarget)->GetFName();
 			}
 			else
 			{
@@ -182,7 +182,7 @@ UAbilitySystemComponent* GetDebugTarget(FASCDebugTargetInfo* Info, const UAbilit
 			{
 				if (!ASC.IsValid()) continue;
 
-				if (ASC->GetAvatarActor_Direct()->GetFName() == SelectActorName)
+				if (GetGASActor(ASC)->GetFName() == SelectActorName)
 				{
 					Info->LastDebugTarget = ASC;
 					bIsSelectActorName = true;
@@ -196,7 +196,7 @@ UAbilitySystemComponent* GetDebugTarget(FASCDebugTargetInfo* Info, const UAbilit
 				if (PlayerComp.IsValidIndex(0) && PlayerComp[0] != nullptr)
 				{
 					Info->LastDebugTarget = PlayerComp[0];
-					SelectActorName = PlayerComp[0]->GetAvatarActor_Direct()->GetFName();
+					SelectActorName = GetGASActor(PlayerComp[0])->GetFName();
 				}
 				else
 				{

--- a/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
+++ b/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
@@ -101,6 +101,27 @@ void UpDataPlayerComp(UWorld* World)
 	}
 }
 
+AActor* GetGASActor(const TWeakObjectPtr<UAbilitySystemComponent>& InASC)
+{
+	if (!InASC.IsValid())
+	{
+		return nullptr;
+	}
+
+	;
+	if (AActor* LocalAvatarActor = InASC->GetAvatarActor_Direct())
+	{
+		return LocalAvatarActor;
+	}
+
+ 	if (AActor* LocalOwnerActor = InASC->GetOwnerActor())
+	{
+		return LocalOwnerActor;
+	}
+
+	return nullptr;
+}
+
 UAbilitySystemComponent* GetDebugTarget(FASCDebugTargetInfo* Info, const UAbilitySystemComponent* InSelectComponent, FName& SelectActorName)
 {
 	// Return target if we already have one

--- a/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
+++ b/Source/GASAttachEditor/Private/SGASAttachEditor.cpp
@@ -932,13 +932,9 @@ FText SGASAttachEditorImpl::GetOverrideTypeDropDownText() const
 {
 	if (SelectAbilitySystemComponent.IsValid())
 	{
-		if (AActor* LocalAvatarActor = SelectAbilitySystemComponent->GetAvatarActor_Direct())
+		if (AActor* LocalGASActor = GetGASActor(SelectAbilitySystemComponent))
 		{
-			return FText::Format(FText::FromString(TEXT("{0}[{1}]")), FText::FromString(LocalAvatarActor->GetName()), GetLocalRoleText(LocalAvatarActor->GetLocalRole()));
-		}
-		else if (AActor* LocalOwnerActor = SelectAbilitySystemComponent->GetOwnerActor())
-		{
-			return FText::Format(FText::FromString(TEXT("{0}[{1}]")), FText::FromString(LocalOwnerActor->GetName()), GetLocalRoleText(LocalOwnerActor->GetLocalRole()));
+			return FText::Format(FText::FromString(TEXT("{0}[{1}]")), FText::FromString(LocalGASActor->GetName()), GetLocalRoleText(LocalGASActor->GetLocalRole()));
 		}
 	}
 


### PR DESCRIPTION
The avatar actor for ASC can be nullptr. `GetGASActor`, in such a case, returns the owner actor instead.
It makes the code safer and fixes crash when the avatar actor is nullptr.

Also, simplified `GetOverrideTypeDropDownText` with the function, as it shortens code and removes code duplication.